### PR TITLE
Fixed windows.sh script

### DIFF
--- a/windows.sh
+++ b/windows.sh
@@ -33,10 +33,14 @@ cd ~/.tmp
 touch tmpfile
 chmod +x tmpfile
 # CHANGE windows username (no password!)
-echo 'VBoxManage --nologo guestcontrol "win10" run --username admin --password RALFqxAbLDEdFfVdgXjPD2Yvk3uqjT4JG8V9yVhrkBAD8jpRjwh4dZmtMxpdHGAn --wait-stdout --exe "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe" -- powershell/arg0 "'Z:\\$1'"' >> tmpfile
+cmd=(VBoxManage --nologo guestcontrol "win10" run --username admin --password RALFqxAbLDEdFfVdgXjPD2Yvk3uqjT4JG8V9yVhrkBAD8jpRjwh4dZmtMxpdHGAn \
+--wait-stdout --exe 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe' -- '"& \"Z:\\'${1}'\""')
+echo "${cmd[@]}" >> tmpfile
 
 #
 # Run the commands in tmpfile for opening the clicked file!
 #
 ./tmpfile &
+# Add delay, since sometimes tmpfile file gets deleted before it starts executing
+sleep 0.2
 rm tmpfile


### PR DESCRIPTION
    - Fixed VirtualBox API call, since the current command didn't work out of the box (at least for me in VirtualBox v 6.1.50).
    - Fixed the command to run a file inside powershell, since the previous version of the command didn't work if there were delimiters (like spaces) in the file name.
    - Added a delay after setting the 'tmpfile' script to run in the background, because occasionally the file was deleted before it was called.